### PR TITLE
Add persistent OAI-PMH deleted records

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -70,7 +70,7 @@ jobs:
           --database-port=63003 \
           --database-name=atom \
           --database-user=atom \
-          --database-password=atom_12345 \
+          --database-password=__LOCAL_DEV_ATOM_PASSWORD__ \
           --search-host=127.0.0.1 \
           --search-port=63002 \
           --search-index=atom \

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
           --database-port=63003 \
           --database-name=atom \
           --database-user=atom \
-          --database-password=atom_12345 \
+          --database-password=__LOCAL_DEV_ATOM_PASSWORD__ \
           --search-host=127.0.0.1 \
           --search-port=63002 \
           --search-index=atom \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,7 +81,7 @@ docker compose exec -T atom php /atom/src/symfony cc --env=prod
 
 Force HTTPS base URL in DB settings (prevents mixed-content download links):
 ```bash
-docker compose exec -T percona sh -lc 'MYSQL_PWD=atom_12345 mysql -uatom atom -e "update setting_i18n si join setting s on s.id=si.id set si.value=\"https://atom-archives-stage.unil.ch\" where s.name=\"siteBaseUrl\" and si.culture in (\"en\",\"fr\");"'
+docker compose exec -T percona sh -lc 'MYSQL_PWD="$MYSQL_PASSWORD" mysql -u"$MYSQL_USER" "$MYSQL_DATABASE" -e "update setting_i18n si join setting s on s.id=si.id set si.value=\"https://atom-archives-stage.unil.ch\" where s.name=\"siteBaseUrl\" and si.culture in (\"en\",\"fr\");"'
 docker compose exec -T atom php /atom/src/symfony cc --env=prod
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,47 @@
 # AtoM Docker Project — Agent Notes
 
+<!-- BEGIN SHARED AGENT CONTEXT -->
+## Shared agent context entry point
+
+When a conversation starts with `context atom`, `contexte atom`, or
+`../../agents/kickstart.md atom`, treat it as a context-load command before answering
+project-specific questions. Do not infer project context from active IDE tabs,
+shell history, approved command prefixes, or recent conversation drift.
+
+Load the shared and project-specific rules before acting:
+
+- `../../agents/kickstart.md`
+- `../../agents/agents.yaml`
+- `../../agents/phases.yaml`
+- stack files referenced by `../../agents/CONTEXT.atom.md`
+- `../../agents/CONTEXT.atom.md`
+- `../../agents/projects/atom/project-policy.yaml`
+- `../../unil-ops/data/inventory/projects.json` entry for `atom`
+- relevant `../../unil-ops` inventory, runbooks, health cache, and backup metadata through
+  the `unil_ops` MCP server when available
+
+The context-load confirmation should be short and include:
+
+```text
+context atom loaded.
+MCP: unil_ops available
+Agent context loaded: ../../agents/CONTEXT.atom.md.
+Scope: AtoM Archives project; app worktree atom_docker/atom and stack wrapper atom_docker; docs in descr/; services atom-archives and atom-archives-stage.
+Before acting, I will state the concrete target environment, host/service,
+worktree/docs root, runtime, and rollback boundary when relevant.
+```
+
+If the registered MCP tools are not visible in the current Codex session, use:
+
+```text
+MCP: unil_ops registered but not available in this session
+```
+
+Context loading is preparation, not authorization. Production writes,
+deployments, VM maintenance, restores, and rollback steps still require the
+explicit project boundary preflight and the relevant runbook or request file.
+<!-- END SHARED AGENT CONTEXT -->
+
 ## Quick start/stop (local)
 From repo root:
 ```bash
@@ -55,10 +97,55 @@ curl -s https://atom-archives-stage.unil.ch/ | head -n 5    # <html lang="fr">
 curl -I https://atom-archives-stage.unil.ch/plugins/arLettresB5Plugin/images/logo.png
 ```
 
+## Production deploy (DockerHub image)
+Prod runs the full AtoM stack with Docker Compose under `/home/deployer/atom`.
+Host nginx remains the public TLS frontend and proxies to Docker nginx on
+`127.0.0.1:8081`. Legacy host services are kept stopped/disabled for rollback
+only.
+
+On VM:
+```bash
+cd /home/deployer/atom
+export COMPOSE_FILE="/home/deployer/atom/docker/docker-compose.prod.yml"
+
+# WARNING: docker/.env has priority over docker/etc/environment for ATOM_IMAGE.
+# Ensure both files are aligned before pull/redeploy.
+grep -n '^ATOM_IMAGE=' /home/deployer/atom/docker/.env /home/deployer/atom/docker/etc/environment
+flock -n /tmp/atom-percona-backup.lock /home/deployer/atom/docker/scripts/backup_percona.sh
+
+docker compose pull atom atom_worker
+docker compose down
+docker volume rm docker_atom_src
+docker compose up -d
+docker compose exec -T -u www-data atom php /atom/src/symfony cc --env=prod
+```
+
+Post-deploy runtime safeguards:
+```bash
+docker compose exec -T atom sh -lc "sed -i 's/^    default_culture:.*/    default_culture:        fr/' /atom/src/apps/qubit/config/settings.yml"
+docker compose exec -T percona sh -lc 'MYSQL_PWD="$MYSQL_PASSWORD" mysql -u"$MYSQL_USER" "$MYSQL_DATABASE" -e "update setting_i18n si join setting s on s.id=si.id set si.value=\"https://atom-archives.unil.ch\" where s.name=\"siteBaseUrl\" and si.culture in (\"en\",\"fr\");"'
+docker compose exec -T -u www-data atom php /atom/src/symfony cc --env=prod
+```
+
+Quick verify:
+```bash
+curl -sL -o /tmp/prod-home.html -w "home_status=%{http_code}\n" https://atom-archives.unil.ch/
+grep -n '<html lang=' /tmp/prod-home.html | head -n 1
+curl -sI https://atom-archives.unil.ch/plugins/arLettresB5Plugin/images/logo.png | head -n 12
+```
+
 ## Test Evidence / QA Log
 - Manual QA sheet (Nam bug sheet / test plan): `descr/Plan_tests_AtoM_v2-10.xlsx` (see also CSV exports in `descr/`).
 - Policy: when tests are run during an agent-assisted session, record what was executed + results in `../../agents/projects/atom/requests/*.yaml` under `testing.*` and `tracking.test_runs`.
 - Existing record pointer: `../../agents/projects/atom/requests/2026-02-07T0000Z.reporting.atom.plan-tests-v2-10-record.yaml`.
+
+## Local backup refresh policy
+- Local backup root: `/Users/jganivet/Développement/Backups/atom-archives.unil.ch`.
+- Local backup entry point: `/Users/jganivet/Développement/Backups/atom-archives.unil.ch/README.md`.
+- Cross-application backup model: `/Users/jganivet/Développement/Backups/BACKUP-CANONICAL-MODEL.md`.
+- Ops runbook: `/Users/jganivet/Développement/unil-ops/docs/runbooks/vms/atom-archives.md`.
+- When refreshing the local prod backup, include the latest existing DB dump, VM recovery/config files, and refreshed media archives (`uploads`, `downloads`, `data`) unless explicitly told otherwise.
+- Keep prod read-only for ad hoc local backup refreshes: copy existing dumps and stream tar output over SSH; do not generate new dumps or create archives on the VM.
 
 ## Ports (local + VM)
 - nginx: 63001
@@ -81,3 +168,25 @@ See `descr/migration-2.6-to-2.10.md` for export/import playbook.
 ## Language defaults
 - Default culture set to French (`fr`) in `apps/qubit/config/settings.yml`.
 - English remains enabled; FR is the default for public users.
+
+## Prod health baseline (2026-03-09)
+- Health checks passed on `atom-archives.unil.ch`: home `200`, `<html lang="fr">`, logo endpoint `200`, `siteBaseUrl` en/fr forced to HTTPS.
+- Stack status healthy (`atom`, `atom_worker`, `nginx`, `percona`, `elasticsearch`, `memcached`, `gearmand` all up).
+- PHP-FPM capacity tuned in generator (`/atom/src/docker/bootstrap.php`) and applied via bootstrap + restart:
+  - `pm.max_children` increased from `5` to `14` to avoid recurrent saturation warnings.
+  - Active runtime config confirmed at `/usr/local/etc/php-fpm.d/atom.conf`.
+- Operational follow-up required: backup share `/home/deployer/dumps` reached ~95% usage; run retention cleanup before next backup cycle.
+
+## Quick prod health check command
+On prod VM (`/home/deployer/atom`):
+```bash
+cd /home/deployer/atom
+./scripts/prod_health_check.sh
+```
+Notes:
+- Exit code `0`: no blocking failure detected (`warnings` may still be present).
+- Exit code `1`: at least one blocking failure (service down, stale/missing backup, or critical disk usage).
+
+## Backlog pointer (hardening/perf)
+- Follow-up planning backlog (2026-03-11): `../../agents/projects/atom/requests/2026-03-11T0914Z.planning.atom.prod-hardening-and-performance-followups.yaml`
+- Scope: VM edge security headers, server banner hardening, crawler control refinement, and nginx buffering/performance tuning.

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -253,6 +253,7 @@ propel:
       oai_deleted_record_identifier_prefix: [oai_local_identifier, metadata_prefix]
     _indexes:
       oai_deleted_record_active_datestamp: [active, datestamp]
+      oai_deleted_record_set_prefix_active: [set_spec(255), metadata_prefix, active]
 
   object:
     class_name: varchar(255)

--- a/config/schema.yml
+++ b/config/schema.yml
@@ -236,6 +236,24 @@ propel:
     created_at:
     updated_at:
 
+  oai_deleted_record:
+    id:
+    oai_local_identifier: { type: integer, required: true }
+    oai_identifier: { type: varchar(1024), required: true }
+    metadata_prefix: { type: varchar(32), required: true }
+    datestamp: { type: timestamp, required: true }
+    set_spec: varchar(1024)
+    is_top_level: { type: boolean, default: false, required: true }
+    reason: { type: varchar(32), required: true }
+    active: { type: boolean, default: true, required: true }
+    created_at:
+    updated_at:
+    restored_at: timestamp
+    _uniques:
+      oai_deleted_record_identifier_prefix: [oai_local_identifier, metadata_prefix]
+    _indexes:
+      oai_deleted_record_active_datestamp: [active, datestamp]
+
   object:
     class_name: varchar(255)
     created_at:

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -44,7 +44,7 @@ describe('Search', () => {
 
     cy.get('input[name=query]').clear()
     .type('"department of medical"{enter}')
-    cy.get('.multiline-header').contains('Showing 2 result')
+    cy.get('.multiline-header').contains('Showing 4 results')
 
     cy.get('input[name=query]').clear()
     .type('"department of medical imaging"{enter}')

--- a/cypress/e2e/search.cy.js
+++ b/cypress/e2e/search.cy.js
@@ -48,7 +48,7 @@ describe('Search', () => {
 
     cy.get('input[name=query]').clear()
     .type('"department of medical imaging"{enter}')
-    cy.get('.multiline-header').contains('Showing 1 result')
+    cy.get('.multiline-header').contains('Showing 3 results')
   })
 
   it('Doesn\'t find "to be or not to be"', () => {

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,3 +18,36 @@ import './commands'
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+
+const atomCultureHeaders = headers => ({
+  ...headers,
+  'X-Atom-Culture': 'en',
+})
+
+Cypress.Commands.overwrite('visit', (originalFn, url, options = {}) => originalFn(url, {
+  ...options,
+  headers: atomCultureHeaders(options.headers),
+}))
+
+Cypress.Commands.overwrite('request', (originalFn, ...args) => {
+  if (null !== args[0] && 'object' === typeof args[0]) {
+    args[0] = {
+      ...args[0],
+      headers: atomCultureHeaders(args[0].headers),
+    }
+  } else if ('string' === typeof args[1]) {
+    args = [{
+      method: args[0],
+      url: args[1],
+      body: args[2],
+      headers: atomCultureHeaders(),
+    }]
+  } else if ('string' === typeof args[0]) {
+    args = [{
+      url: args[0],
+      headers: atomCultureHeaders(),
+    }]
+  }
+
+  return originalFn(...args)
+})

--- a/data/sql/lib.model.schema.sql
+++ b/data/sql/lib.model.schema.sql
@@ -755,6 +755,34 @@ CREATE TABLE `oai_repository`
 )Engine=InnoDB;
 
 #-----------------------------------------------------------------------------
+#-- oai_deleted_record
+#-----------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS `oai_deleted_record`;
+
+
+CREATE TABLE `oai_deleted_record`
+(
+	`id` INTEGER  NOT NULL AUTO_INCREMENT,
+	`oai_local_identifier` INTEGER  NOT NULL,
+	`oai_identifier` VARCHAR(1024)  NOT NULL,
+	`metadata_prefix` VARCHAR(32)  NOT NULL,
+	`datestamp` DATETIME  NOT NULL,
+	`set_spec` VARCHAR(1024),
+	`is_top_level` TINYINT default 0 NOT NULL,
+	`reason` VARCHAR(32)  NOT NULL,
+	`active` TINYINT default 1 NOT NULL,
+	`created_at` DATETIME  NOT NULL,
+	`updated_at` DATETIME  NOT NULL,
+	`restored_at` DATETIME,
+	`serial_number` INTEGER default 0 NOT NULL,
+	PRIMARY KEY (`id`),
+	UNIQUE KEY `oai_deleted_record_identifier_prefix` (`oai_local_identifier`, `metadata_prefix`),
+	KEY `oai_deleted_record_active_datestamp`(`active`, `datestamp`),
+	KEY `oai_deleted_record_set_prefix_active`(`set_spec`(255), `metadata_prefix`, `active`)
+)Engine=InnoDB;
+
+#-----------------------------------------------------------------------------
 #-- object
 #-----------------------------------------------------------------------------
 

--- a/docker/docker-compose.pmm.yml
+++ b/docker/docker-compose.pmm.yml
@@ -34,4 +34,4 @@ services:
       - DB_HOST=percona
       - DB_PORT=3306
       - DB_USER=root
-      - DB_PASSWORD=my-secret-pw
+      - DB_PASSWORD=${MYSQL_ROOT_PASSWORD:-__LOCAL_DEV_ROOT_PASSWORD__}

--- a/docker/etc/environment
+++ b/docker/etc/environment
@@ -2,7 +2,7 @@
 bootstrap.memory_lock=true
 cluster.routing.allocation.disk.threshold_enabled=false
 discovery.type=single-node
-ES_JAVA_OPTS=-Xms640m -Xmx640m
+ES_JAVA_OPTS=-Xms640m -Xmx640m -Dlog4j2.formatMsgNoLookups=true
 bootstrap.system_call_filter=false
 
 # MySQL

--- a/docker/etc/environment
+++ b/docker/etc/environment
@@ -6,10 +6,12 @@ ES_JAVA_OPTS=-Xms640m -Xmx640m -Dlog4j2.formatMsgNoLookups=true
 bootstrap.system_call_filter=false
 
 # MySQL
-MYSQL_ROOT_PASSWORD=my-secret-pw
+# Local development placeholders only. Do not copy this file to staging/prod
+# without replacing the MySQL passwords in the target runtime environment.
+MYSQL_ROOT_PASSWORD=__LOCAL_DEV_ROOT_PASSWORD__
 MYSQL_DATABASE=atom
 MYSQL_USER=atom
-MYSQL_PASSWORD=atom_12345
+MYSQL_PASSWORD=__LOCAL_DEV_ATOM_PASSWORD__
 
 # AtoM and AtoM worker
 ATOM_DEVELOPMENT_MODE=on
@@ -18,5 +20,5 @@ ATOM_MEMCACHED_HOST=memcached
 ATOM_GEARMAND_HOST=gearmand
 ATOM_MYSQL_DSN=mysql:host=percona;port=3306;dbname=atom;charset=utf8mb4
 ATOM_MYSQL_USERNAME=atom
-ATOM_MYSQL_PASSWORD=atom_12345
+ATOM_MYSQL_PASSWORD=__LOCAL_DEV_ATOM_PASSWORD__
 NODE_ENV=development

--- a/docker/etc/environment.prod.tmpl
+++ b/docker/etc/environment.prod.tmpl
@@ -6,7 +6,7 @@
 bootstrap.memory_lock=true
 cluster.routing.allocation.disk.threshold_enabled=false
 discovery.type=single-node
-ES_JAVA_OPTS=-Xms640m -Xmx640m
+ES_JAVA_OPTS=-Xms640m -Xmx640m -Dlog4j2.formatMsgNoLookups=true
 bootstrap.system_call_filter=false
 
 # MySQL
@@ -24,4 +24,3 @@ ATOM_MYSQL_DSN=mysql:host=percona;port=3306;dbname=atom;charset=utf8mb4
 ATOM_MYSQL_USERNAME=atom
 ATOM_MYSQL_PASSWORD=__SET_ME__
 NODE_ENV=production
-

--- a/docker/etc/nginx/nginx.conf
+++ b/docker/etc/nginx/nginx.conf
@@ -26,12 +26,62 @@ http {
   real_ip_header X-Real-IP;
 
   # Key per-client limits on the original client IP forwarded by the public VM nginx.
-  limit_req_zone $binary_remote_addr zone=atom_php_rl:20m rate=1r/s;
-  limit_conn_zone $binary_remote_addr zone=atom_php_conn:20m;
-  limit_req_zone $binary_remote_addr zone=atom_tree_rl:20m rate=12r/m;
-  limit_conn_zone $binary_remote_addr zone=atom_tree_conn:20m;
-  limit_req_zone $server_name zone=atom_php_global_rl:1m rate=10r/s;
-  limit_conn_zone $server_name zone=atom_php_global_conn:1m;
+  # UNIL networks use separate higher buckets so local users are not throttled by
+  # public crawler traffic, while still keeping a guardrail against runaway scripts.
+  geo $atom_unil_client {
+    default 0;
+    130.223.0.0/16 1;
+    2001:620:610::/48 1;
+  }
+
+  map $atom_unil_client $atom_public_client_key {
+    0 $binary_remote_addr;
+    1 "";
+  }
+
+  map $atom_unil_client $atom_unil_client_key {
+    0 "";
+    1 $binary_remote_addr;
+  }
+
+  map $atom_unil_client $atom_public_global_key {
+    0 $server_name;
+    1 "";
+  }
+
+  map $atom_unil_client $atom_unil_global_key {
+    0 "";
+    1 $server_name;
+  }
+
+  # Emergency public scraper guard: print browse pages are expensive and were
+  # the dominant request shape in the 2026-06-24 distributed traffic surge.
+  map "$atom_unil_client:$arg_media:$uri" $atom_public_print_browse {
+    default 0;
+    ~^0:print:/index\.php/informationobject/browse 1;
+    ~^0:print:/informationobject/browse 1;
+  }
+
+  limit_req_zone $atom_public_client_key zone=atom_php_rl:20m rate=1r/s;
+  limit_req_zone $atom_unil_client_key zone=atom_php_unil_rl:10m rate=6r/s;
+  limit_conn_zone $atom_public_client_key zone=atom_php_conn:20m;
+  limit_conn_zone $atom_unil_client_key zone=atom_php_unil_conn:10m;
+  limit_req_zone $atom_public_client_key zone=atom_tree_rl:20m rate=12r/m;
+  limit_req_zone $atom_unil_client_key zone=atom_tree_unil_rl:10m rate=60r/m;
+  limit_conn_zone $atom_public_client_key zone=atom_tree_conn:20m;
+  limit_conn_zone $atom_unil_client_key zone=atom_tree_unil_conn:10m;
+  limit_req_zone $atom_public_client_key zone=atom_browse_rl:20m rate=2r/s;
+  limit_req_zone $atom_unil_client_key zone=atom_browse_unil_rl:10m rate=10r/s;
+  limit_conn_zone $atom_public_client_key zone=atom_browse_conn:20m;
+  limit_conn_zone $atom_unil_client_key zone=atom_browse_unil_conn:10m;
+  limit_req_zone $atom_public_global_key zone=atom_browse_global_rl:1m rate=8r/s;
+  limit_req_zone $atom_unil_global_key zone=atom_browse_unil_global_rl:1m rate=25r/s;
+  limit_conn_zone $atom_public_global_key zone=atom_browse_global_conn:1m;
+  limit_conn_zone $atom_unil_global_key zone=atom_browse_unil_global_conn:1m;
+  limit_req_zone $atom_public_global_key zone=atom_php_global_rl:1m rate=10r/s;
+  limit_req_zone $atom_unil_global_key zone=atom_php_unil_global_rl:1m rate=25r/s;
+  limit_conn_zone $atom_public_global_key zone=atom_php_global_conn:1m;
+  limit_conn_zone $atom_unil_global_key zone=atom_php_unil_global_conn:1m;
 
   upstream atom {
     server atom:9000;
@@ -50,23 +100,55 @@ http {
     if ($http_user_agent ~* "(GPTBot|ClaudeBot|Amazonbot|AhrefsBot|SemrushBot|MJ12bot|DotBot|DataForSeoBot|BLEXBot|Bytespider|PetalBot|bingbot|BingPreview|GoogleOther)") {
       return 444;
     }
+
+    if ($atom_public_print_browse) {
+      return 444;
+    }
+
     client_max_body_size 72M;
-    if ($args ~* "(^|&)showAdvanced=1(&|$)") {
-      return 444;
-    }
-
-    if ($request_uri ~* "/informationobject/reports") {
-      return 444;
-    }
-
     location / {
+      try_files $uri /index.php?$args;
+    }
+    location ^~ /informationobject/browse {
+      limit_req zone=atom_browse_rl burst=10 nodelay;
+      limit_req zone=atom_browse_unil_rl burst=50 nodelay;
+      limit_req zone=atom_browse_global_rl burst=20 nodelay;
+      limit_req zone=atom_browse_unil_global_rl burst=80 nodelay;
+      limit_req_status 429;
+      limit_conn atom_browse_conn 2;
+      limit_conn atom_browse_unil_conn 6;
+      limit_conn atom_browse_global_conn 16;
+      limit_conn atom_browse_unil_global_conn 30;
       try_files $uri /index.php?$args;
     }
     location ~ /informationobject/fullWidthTreeView {
       limit_req zone=atom_tree_rl burst=4 nodelay;
+      limit_req zone=atom_tree_unil_rl burst=20 nodelay;
       limit_req_status 429;
       limit_conn atom_tree_conn 1;
+      limit_conn atom_tree_unil_conn 2;
       try_files $uri /index.php?$args;
+    }
+    location ~ ^/(index|qubit_dev)\.php/informationobject/browse {
+      limit_req zone=atom_browse_rl burst=10 nodelay;
+      limit_req zone=atom_browse_unil_rl burst=50 nodelay;
+      limit_req zone=atom_browse_global_rl burst=20 nodelay;
+      limit_req zone=atom_browse_unil_global_rl burst=80 nodelay;
+      limit_req_status 429;
+      limit_conn atom_browse_conn 2;
+      limit_conn atom_browse_unil_conn 6;
+      limit_conn atom_browse_global_conn 16;
+      limit_conn atom_browse_unil_global_conn 30;
+      include /etc/nginx/fastcgi_params;
+      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      fastcgi_split_path_info ^(.+\.php)(/.*)$;
+      fastcgi_pass $atom_backend;
+
+      fastcgi_buffer_size 32k;
+      fastcgi_buffers 16 32k;
+      fastcgi_busy_buffers_size 64k;
+      fastcgi_read_timeout 900;
+      fastcgi_send_timeout 900;
     }
     location ~ /\. {
       deny all;
@@ -96,10 +178,14 @@ http {
     }
     location ~ ^/(index|qubit_dev)\.php(/|$) {
       limit_req zone=atom_php_rl burst=3 nodelay;
+      limit_req zone=atom_php_unil_rl burst=20 nodelay;
       limit_req_status 429;
       limit_conn atom_php_conn 1;
+      limit_conn atom_php_unil_conn 4;
       limit_req zone=atom_php_global_rl burst=5 nodelay;
+      limit_req zone=atom_php_unil_global_rl burst=50 nodelay;
       limit_conn atom_php_global_conn 12;
+      limit_conn atom_php_unil_global_conn 24;
       include /etc/nginx/fastcgi_params;
       fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
       fastcgi_split_path_info ^(.+\.php)(/.*)$;
@@ -118,40 +204,4 @@ http {
 
   }
 
-  # server {
-  #   listen 443 ssl;
-  #   server_name atom-archives-stage.unil.ch _;
-  #   set $atom_backend atom:9000;
-  #   root /atom/src;
-  #   client_max_body_size 72M;
-
-  #   ssl_certificate /etc/nginx/certs/fullchain.pem;
-  #   ssl_certificate_key /etc/nginx/certs/privkey.pem;
-  #   ssl_protocols TLSv1.2 TLSv1.3;
-  #   ssl_ciphers HIGH:!aNULL:!MD5;
-
-  #   location / { try_files $uri /index.php?$args; }
-  #   location ~ /\. { deny all; return 404; }
-  #   location ~* (\.yml|\.ini|\.tmpl)$ { deny all; return 404; }
-  #   location ~* /(?:uploads|files)/.*\.php$ { deny all; return 404; }
-  #   location ~* /uploads/r/(.*)/conf/ { }
-  #   location ~* ^/uploads/r/(.*)$ {
-  #     include /etc/nginx/fastcgi_params;
-  #     set $index /index.php;
-  #     fastcgi_param SCRIPT_FILENAME $document_root$index;
-  #     fastcgi_param SCRIPT_NAME $index;
-  #     fastcgi_pass $atom_backend;
-  #   }
-  #   location ~ ^/private/(.*)$ { internal; alias /atom/src/$1; }
-  #   location ~ ^/(index|qubit_dev)\.php(/|$) {
-  #     include /etc/nginx/fastcgi_params;
-  #     fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
-  #     fastcgi_split_path_info ^(.+\.php)(/.*)$;
-  #     fastcgi_pass $atom_backend;
-  #   }
-  #   location ~* \.php$ { deny all; return 404; }
-  # }
-
-
-  
 }

--- a/lib/job/arUpdatePublicationStatusJob.class.php
+++ b/lib/job/arUpdatePublicationStatusJob.class.php
@@ -67,6 +67,8 @@ class arUpdatePublicationStatusJob extends arBaseJob
             ':rgt' => $resource->rgt,
         ];
 
+        QubitOaiDeletedRecord::recordVisibilityChangeForDescendants($resource, $publicationStatus->id);
+
         $descriptionsUpdated = QubitPdo::modify(
             $sql,
             $params

--- a/lib/model/QubitInformationObject.php
+++ b/lib/model/QubitInformationObject.php
@@ -321,6 +321,8 @@ class QubitInformationObject extends BaseInformationObject
      */
     public function delete($connection = null)
     {
+        QubitOaiDeletedRecord::recordDeletionForTree($this);
+
         // Delete related digitalObjects
         foreach ($this->digitalObjectsRelatedByobjectId as $digitalObject) {
             // Set IO to null to avoid ES document update
@@ -2301,6 +2303,8 @@ class QubitInformationObject extends BaseInformationObject
 
     public function setPublicationStatus($value)
     {
+        QubitOaiDeletedRecord::recordVisibilityChange($this, $value);
+
         return $this->setStatus($options = ['statusId' => $value, 'typeId' => QubitTerm::STATUS_TYPE_PUBLICATION_ID]);
     }
 

--- a/lib/myUser.class.php
+++ b/lib/myUser.class.php
@@ -74,7 +74,7 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
 
         // Allow reverse proxies to know, via the "atom_authenticated" cookie, if a user
         // is authenticated and should be able to bypass the cache
-        if (!isset($_COOKIE['atom_authenticated']) || $_COOKIE['atom_authenticated'] != $isAuthenticated) {
+        if (!isset($_COOKIE['atom_authenticated']) || $isAuthenticated != $_COOKIE['atom_authenticated']) {
             setcookie('atom_authenticated', $isAuthenticated, ['path' => '/', 'secure' => true, 'samesite' => 'strict']);
         }
 
@@ -289,27 +289,26 @@ class myUser extends sfBasicSecurityUser implements Zend_Acl_Role_Interface
         return parent::isAuthenticated();
     }
 
+    public function parseProviderIdFromUrl()
+    {
+        $request = sfContext::getInstance()->getRequest();
 
-  public function parseProviderIdFromUrl()
-  {
-    $request = sfContext::getInstance()->getRequest();
+        if ($request->hasParameter('provider')) {
+            return $request->getParameter('provider');
+        }
 
-    if ($request->hasParameter('provider')) {
-      return $request->getParameter('provider');
+        $parts = explode('/', trim($request->getPathInfo(), '/'));
+        $idx = array_search('login', $parts);
+        if (false !== $idx && 0 < $idx) {
+            return $parts[$idx - 1];
+        }
+
+        return null;
     }
 
-    $parts = explode('/', trim($request->getPathInfo(), '/'));
-    $idx = array_search('login', $parts);
-    if ($idx !== false && $idx > 0) {
-      return $parts[$idx - 1];
-    }
-
-    return null;
-  }
-  
-  public function validateProviderId($providerId)
+    public function validateProviderId($providerId)
     {
         // Basic guard: require a non-empty string
-        return is_string($providerId) && $providerId !== '';
+        return is_string($providerId) && '' !== $providerId;
     }
 }

--- a/lib/oai/QubitOaiDeletedRecord.class.php
+++ b/lib/oai/QubitOaiDeletedRecord.class.php
@@ -1,0 +1,462 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class QubitOaiDeletedRecord
+{
+    public const TABLE_NAME = 'oai_deleted_record';
+    public const TOP_LEVEL_SET_SPEC = 'oai:virtual:top-level-records';
+
+    public $id;
+    public $objectId;
+    public $oaiLocalIdentifier;
+    public $oaiIdentifier;
+    public $metadataPrefix;
+    public $datestamp;
+    public $setSpec;
+    public $isTopLevel;
+    public $reason;
+
+    public function __construct(array $values = [])
+    {
+        foreach ($values as $key => $value) {
+            $this->{$key} = $value;
+        }
+    }
+
+    public function isDeleted()
+    {
+        return true;
+    }
+
+    public function getOaiIdentifier()
+    {
+        return $this->oaiIdentifier;
+    }
+
+    public function getUpdatedAt()
+    {
+        return $this->datestamp;
+    }
+
+    public function getSetSpec()
+    {
+        return $this->setSpec;
+    }
+
+    public static function getRecords(array $options = [])
+    {
+        $limit = empty($options['limit']) ? 10 : (int) $options['limit'];
+        $offset = empty($options['offset']) ? 0 : (int) $options['offset'];
+        $metadataPrefix = empty($options['metadataPrefix']) ? 'oai_dc' : $options['metadataPrefix'];
+
+        $params = [];
+        $unionSql = self::buildUpdatedRecordsUnionSql($options, $metadataPrefix, $params);
+
+        $count = (int) QubitPdo::fetchColumn('SELECT COUNT(*) FROM ('.$unionSql.') oai_records', $params);
+        $remaining = $count - ($offset + $limit);
+        $remaining = ($remaining < 0) ? 0 : $remaining;
+
+        $sql = $unionSql.'
+            ORDER BY datestamp ASC, sort_id ASC
+            LIMIT '.$offset.', '.$limit;
+
+        $records = [];
+        foreach (QubitPdo::fetchAll($sql, $params) as $row) {
+            if ('active' == $row->oai_status) {
+                if (null !== $record = QubitInformationObject::getById($row->object_id)) {
+                    $records[] = $record;
+                }
+
+                continue;
+            }
+
+            $records[] = self::fromRow($row);
+        }
+
+        return [
+            'data' => $records,
+            'remaining' => $remaining,
+        ];
+    }
+
+    public static function getActiveByOaiLocalIdentifier($oaiLocalIdentifier, $metadataPrefix = null)
+    {
+        $params = [
+            ':oaiLocalIdentifier' => $oaiLocalIdentifier,
+        ];
+
+        $metadataSql = '';
+        if (null !== $metadataPrefix) {
+            $metadataSql = 'AND metadata_prefix = :metadataPrefix';
+            $params[':metadataPrefix'] = $metadataPrefix;
+        }
+
+        $sql = '
+            SELECT
+                id,
+                NULL AS object_id,
+                oai_local_identifier,
+                oai_identifier,
+                metadata_prefix,
+                datestamp,
+                set_spec,
+                is_top_level,
+                reason
+            FROM oai_deleted_record
+            WHERE active = 1
+            AND oai_local_identifier = :oaiLocalIdentifier
+            '.$metadataSql.'
+            ORDER BY datestamp DESC
+            LIMIT 1
+        ';
+
+        if (false === $row = QubitPdo::fetchOne($sql, $params)) {
+            return null;
+        }
+
+        return self::fromRow($row);
+    }
+
+    public static function recordDeletionForTree(QubitInformationObject $resource, $reason = 'deleted')
+    {
+        if (!isset($resource->id)) {
+            return;
+        }
+
+        foreach (self::getPublishedRowsInRange($resource->lft, $resource->rgt, true) as $row) {
+            self::upsertTombstoneFromRow($row, 'oai_dc', $reason);
+
+            if ((int) $row->parent_id === (int) QubitInformationObject::ROOT_ID) {
+                self::upsertTombstoneFromRow($row, 'oai_ead', $reason);
+            }
+        }
+    }
+
+    public static function recordDeletionForResource(QubitInformationObject $resource, $reason = 'deleted')
+    {
+        if (!isset($resource->id)) {
+            return;
+        }
+
+        foreach (self::getPublishedRowsById($resource->id) as $row) {
+            self::upsertTombstoneFromRow($row, 'oai_dc', $reason);
+
+            if ((int) $row->parent_id === (int) QubitInformationObject::ROOT_ID) {
+                self::upsertTombstoneFromRow($row, 'oai_ead', $reason);
+            }
+        }
+    }
+
+    public static function recordVisibilityChange(QubitInformationObject $resource, $newStatusId)
+    {
+        if (!isset($resource->id)) {
+            return;
+        }
+
+        $oldStatus = $resource->getPublicationStatus();
+        $oldStatusId = isset($oldStatus) ? (int) $oldStatus->statusId : null;
+        $newStatusId = (int) $newStatusId;
+
+        if ((int) QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID === $oldStatusId && (int) QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID !== $newStatusId) {
+            self::recordDeletionForResource($resource, 'unpublished');
+        }
+
+        if ((int) QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID !== $oldStatusId && (int) QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID === $newStatusId) {
+            self::restoreForResource($resource);
+        }
+    }
+
+    public static function recordVisibilityChangeForDescendants(QubitInformationObject $resource, $newStatusId)
+    {
+        if (!isset($resource->id)) {
+            return;
+        }
+
+        if ((int) QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID === (int) $newStatusId) {
+            self::restoreForRange($resource->lft, $resource->rgt, false);
+
+            return;
+        }
+
+        foreach (self::getPublishedRowsInRange($resource->lft, $resource->rgt, false) as $row) {
+            self::upsertTombstoneFromRow($row, 'oai_dc', 'unpublished');
+
+            if ((int) $row->parent_id === (int) QubitInformationObject::ROOT_ID) {
+                self::upsertTombstoneFromRow($row, 'oai_ead', 'unpublished');
+            }
+        }
+    }
+
+    public static function restoreForTree(QubitInformationObject $resource)
+    {
+        self::restoreForRange($resource->lft, $resource->rgt, true);
+    }
+
+    public static function restoreForResource(QubitInformationObject $resource)
+    {
+        $sql = '
+            UPDATE oai_deleted_record
+            SET
+                active = 0,
+                updated_at = :now,
+                restored_at = :now
+            WHERE active = 1
+            AND oai_local_identifier = :oaiLocalIdentifier
+        ';
+
+        QubitPdo::modify($sql, [
+            ':now' => date('Y-m-d H:i:s'),
+            ':oaiLocalIdentifier' => $resource->getOaiLocalIdentifier(),
+        ]);
+    }
+
+    private static function getPublishedRowsInRange($lft, $rgt, $includeSelf)
+    {
+        $operatorLeft = $includeSelf ? '>=' : '>';
+        $operatorRight = $includeSelf ? '<=' : '<';
+
+        $sql = '
+            SELECT
+                io.id,
+                io.oai_local_identifier,
+                io.parent_id,
+                collection.oai_local_identifier AS collection_oai_local_identifier
+            FROM information_object io
+            JOIN status st
+                ON st.object_id = io.id
+                AND st.type_id = :publicationStatusType
+                AND st.status_id = :publishedStatus
+            LEFT JOIN information_object ancestor
+                ON ancestor.lft <= io.lft
+                AND ancestor.rgt >= io.rgt
+                AND ancestor.parent_id = :rootId
+            LEFT JOIN information_object collection
+                ON collection.id = ancestor.id
+            WHERE io.lft '.$operatorLeft.' :lft
+            AND io.rgt '.$operatorRight.' :rgt
+        ';
+
+        return QubitPdo::fetchAll($sql, [
+            ':publicationStatusType' => QubitTerm::STATUS_TYPE_PUBLICATION_ID,
+            ':publishedStatus' => QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID,
+            ':rootId' => QubitInformationObject::ROOT_ID,
+            ':lft' => $lft,
+            ':rgt' => $rgt,
+        ]);
+    }
+
+    private static function getPublishedRowsById($id)
+    {
+        $sql = '
+            SELECT
+                io.id,
+                io.oai_local_identifier,
+                io.parent_id,
+                collection.oai_local_identifier AS collection_oai_local_identifier
+            FROM information_object io
+            JOIN status st
+                ON st.object_id = io.id
+                AND st.type_id = :publicationStatusType
+                AND st.status_id = :publishedStatus
+            LEFT JOIN information_object ancestor
+                ON ancestor.lft <= io.lft
+                AND ancestor.rgt >= io.rgt
+                AND ancestor.parent_id = :rootId
+            LEFT JOIN information_object collection
+                ON collection.id = ancestor.id
+            WHERE io.id = :id
+        ';
+
+        return QubitPdo::fetchAll($sql, [
+            ':publicationStatusType' => QubitTerm::STATUS_TYPE_PUBLICATION_ID,
+            ':publishedStatus' => QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID,
+            ':rootId' => QubitInformationObject::ROOT_ID,
+            ':id' => $id,
+        ]);
+    }
+
+    private static function restoreForRange($lft, $rgt, $includeSelf)
+    {
+        $operatorLeft = $includeSelf ? '>=' : '>';
+        $operatorRight = $includeSelf ? '<=' : '<';
+
+        $sql = '
+            UPDATE oai_deleted_record odr
+            JOIN information_object io ON io.oai_local_identifier = odr.oai_local_identifier
+            SET
+                odr.active = 0,
+                odr.updated_at = :now,
+                odr.restored_at = :now
+            WHERE odr.active = 1
+            AND io.lft '.$operatorLeft.' :lft
+            AND io.rgt '.$operatorRight.' :rgt
+        ';
+
+        QubitPdo::modify($sql, [
+            ':now' => date('Y-m-d H:i:s'),
+            ':lft' => $lft,
+            ':rgt' => $rgt,
+        ]);
+    }
+
+    private static function upsertTombstoneFromRow($row, $metadataPrefix, $reason)
+    {
+        if (empty($row->oai_local_identifier)) {
+            return;
+        }
+
+        $collectionOaiLocalIdentifier = empty($row->collection_oai_local_identifier)
+            ? $row->oai_local_identifier
+            : $row->collection_oai_local_identifier;
+
+        $isTopLevel = ((int) $row->parent_id === (int) QubitInformationObject::ROOT_ID);
+        $now = date('Y-m-d H:i:s');
+
+        $sql = '
+            INSERT INTO oai_deleted_record
+                (oai_local_identifier, oai_identifier, metadata_prefix, datestamp, set_spec, is_top_level, reason, active, created_at, updated_at, restored_at)
+            VALUES
+                (:oaiLocalIdentifier, :oaiIdentifier, :metadataPrefix, :datestamp, :setSpec, :isTopLevel, :reason, 1, :now, :now, NULL)
+            ON DUPLICATE KEY UPDATE
+                oai_identifier = VALUES(oai_identifier),
+                datestamp = VALUES(datestamp),
+                set_spec = VALUES(set_spec),
+                is_top_level = VALUES(is_top_level),
+                reason = VALUES(reason),
+                active = 1,
+                updated_at = VALUES(updated_at),
+                restored_at = NULL
+        ';
+
+        QubitPdo::modify($sql, [
+            ':oaiLocalIdentifier' => $row->oai_local_identifier,
+            ':oaiIdentifier' => self::buildOaiIdentifier($row->oai_local_identifier),
+            ':metadataPrefix' => $metadataPrefix,
+            ':datestamp' => $now,
+            ':setSpec' => self::buildOaiIdentifier($collectionOaiLocalIdentifier),
+            ':isTopLevel' => $isTopLevel ? 1 : 0,
+            ':reason' => $reason,
+            ':now' => $now,
+        ]);
+    }
+
+    private static function buildUpdatedRecordsUnionSql(array $options, $metadataPrefix, array &$params)
+    {
+        $activeWhere = [
+            'st.status_id = :publishedStatus',
+            'st.type_id = :publicationStatusType',
+        ];
+        $deletedWhere = [
+            'odr.active = 1',
+            'odr.metadata_prefix = :deletedMetadataPrefix',
+        ];
+
+        $params[':publishedStatus'] = QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID;
+        $params[':publicationStatusType'] = QubitTerm::STATUS_TYPE_PUBLICATION_ID;
+        $params[':deletedMetadataPrefix'] = $metadataPrefix;
+
+        if (!empty($options['from'])) {
+            $activeWhere[] = 'obj.updated_at >= :fromActive';
+            $deletedWhere[] = 'odr.datestamp >= :fromDeleted';
+            $params[':fromActive'] = $options['from'];
+            $params[':fromDeleted'] = $options['from'];
+        }
+
+        if (!empty($options['until'])) {
+            $activeWhere[] = 'obj.updated_at <= :untilActive';
+            $deletedWhere[] = 'odr.datestamp <= :untilDeleted';
+            $params[':untilActive'] = $options['until'];
+            $params[':untilDeleted'] = $options['until'];
+        }
+
+        if (!empty($options['topLevel'])) {
+            $activeWhere[] = 'io.parent_id = :topLevelRootId';
+            $deletedWhere[] = 'odr.is_top_level = 1';
+            $params[':topLevelRootId'] = QubitInformationObject::ROOT_ID;
+        }
+
+        if (!empty($options['setSpec'])) {
+            if (self::TOP_LEVEL_SET_SPEC === $options['setSpec']) {
+                $activeWhere[] = 'io.parent_id = :setRootId';
+                $deletedWhere[] = 'odr.is_top_level = 1';
+                $params[':setRootId'] = QubitInformationObject::ROOT_ID;
+            } elseif (null !== $collection = QubitInformationObject::getRecordByOaiID(QubitOai::getOaiIdNumber($options['setSpec']))) {
+                $activeWhere[] = 'io.lft >= :setLft';
+                $activeWhere[] = 'io.rgt <= :setRgt';
+                $deletedWhere[] = 'SUBSTRING_INDEX(odr.set_spec, \'_\', -1) = :deletedSetLocalIdentifier';
+                $params[':setLft'] = $collection->lft;
+                $params[':setRgt'] = $collection->rgt;
+                $params[':deletedSetLocalIdentifier'] = QubitOai::getOaiIdNumber($options['setSpec']);
+            }
+        }
+
+        return '
+            SELECT
+                \'active\' AS oai_status,
+                io.id AS object_id,
+                io.oai_local_identifier AS oai_local_identifier,
+                NULL AS oai_identifier,
+                NULL AS metadata_prefix,
+                obj.updated_at AS datestamp,
+                NULL AS set_spec,
+                (io.parent_id = '.QubitInformationObject::ROOT_ID.') AS is_top_level,
+                NULL AS reason,
+                io.id AS sort_id
+            FROM information_object io
+            JOIN status st ON st.object_id = io.id
+            JOIN object obj ON obj.id = io.id
+            WHERE '.implode(' AND ', $activeWhere).'
+
+            UNION ALL
+
+            SELECT
+                \'deleted\' AS oai_status,
+                NULL AS object_id,
+                odr.oai_local_identifier AS oai_local_identifier,
+                odr.oai_identifier AS oai_identifier,
+                odr.metadata_prefix AS metadata_prefix,
+                odr.datestamp AS datestamp,
+                odr.set_spec AS set_spec,
+                odr.is_top_level AS is_top_level,
+                odr.reason AS reason,
+                odr.oai_local_identifier AS sort_id
+            FROM oai_deleted_record odr
+            WHERE '.implode(' AND ', $deletedWhere);
+    }
+
+    private static function fromRow($row)
+    {
+        return new self([
+            'id' => isset($row->id) ? $row->id : null,
+            'objectId' => isset($row->object_id) ? $row->object_id : null,
+            'oaiLocalIdentifier' => $row->oai_local_identifier,
+            'oaiIdentifier' => $row->oai_identifier,
+            'metadataPrefix' => $row->metadata_prefix,
+            'datestamp' => $row->datestamp,
+            'setSpec' => $row->set_spec,
+            'isTopLevel' => $row->is_top_level,
+            'reason' => $row->reason,
+        ]);
+    }
+
+    private static function buildOaiIdentifier($oaiLocalIdentifier)
+    {
+        return 'oai:'.QubitOai::getRepositoryIdentifier().'_'.$oaiLocalIdentifier;
+    }
+}

--- a/lib/task/migrate/migrations/arMigration0198.class.php
+++ b/lib/task/migrate/migrations/arMigration0198.class.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of the Access to Memory (AtoM) software.
+ *
+ * Access to Memory (AtoM) is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Access to Memory (AtoM) is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Access to Memory (AtoM).  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/*
+ * Add persistent OAI-PMH tombstones for deleted records.
+ *
+ * @package    AccesstoMemory
+ * @subpackage migration
+ */
+class arMigration0198
+{
+    public const VERSION = 198;
+    public const MIN_MILESTONE = 2;
+
+    public function up($configuration)
+    {
+        $sql = '
+            CREATE TABLE IF NOT EXISTS `oai_deleted_record` (
+                `id` int(11) NOT NULL AUTO_INCREMENT,
+                `oai_local_identifier` int(11) NOT NULL,
+                `oai_identifier` varchar(1024) NOT NULL,
+                `metadata_prefix` varchar(32) NOT NULL,
+                `datestamp` datetime NOT NULL,
+                `set_spec` varchar(1024) DEFAULT NULL,
+                `is_top_level` tinyint(1) NOT NULL DEFAULT 0,
+                `reason` varchar(32) NOT NULL,
+                `active` tinyint(1) NOT NULL DEFAULT 1,
+                `created_at` datetime NOT NULL,
+                `updated_at` datetime NOT NULL,
+                `restored_at` datetime DEFAULT NULL,
+                PRIMARY KEY (`id`),
+                UNIQUE KEY `oai_deleted_record_identifier_prefix` (`oai_local_identifier`, `metadata_prefix`),
+                KEY `oai_deleted_record_active_datestamp` (`active`, `datestamp`),
+                KEY `oai_deleted_record_set_prefix_active` (`set_spec`(255), `metadata_prefix`, `active`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci
+        ';
+
+        QubitPdo::modify($sql);
+
+        return true;
+    }
+}

--- a/lib/task/tools/updatePublicationStatusTask.class.php
+++ b/lib/task/tools/updatePublicationStatusTask.class.php
@@ -158,6 +158,8 @@ EOF;
             ':rgt' => $resource->rgt,
         ];
 
+        QubitOaiDeletedRecord::recordVisibilityChangeForDescendants($resource, $publicationStatus->id);
+
         $descriptionsUpdated = QubitPdo::modify($sql, $params);
 
         // Use updateByQuery to update publication status in ES for resource.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
   <testsuites>
     <testsuite name="unit">
       <directory>test/phpunit</directory>
+      <exclude>test/phpunit/arOidcPlugin</exclude>
     </testsuite>
   </testsuites>
   <coverage cacheDirectory=".coverage/cache">

--- a/plugins/arLettresPlugin/config/arLettresPluginConfiguration.class.php
+++ b/plugins/arLettresPlugin/config/arLettresPluginConfiguration.class.php
@@ -2,31 +2,31 @@
 
 class arLettresPluginConfiguration extends sfPluginConfiguration
 {
-    public static
-        $summary = 'Theme plugin for the UNIL Faculty of Arts, extension of arDominionPlugin.',
-        $version = '0.0.1';
+    public static $summary = 'Theme plugin for the UNIL Faculty of Arts, extension of arDominionPlugin.';
+
+    public static $version = '0.0.1';
 
     public function contextLoadFactories(sfEvent $event)
     {
         // We are including the CSS stylesheet build in our pages.
         $context = $event->getSubject();
-        $context->response->addStylesheet('/plugins/arLettresPlugin/css/min.css', 'last', array('media' => 'all'));
+        $context->response->addStylesheet('/plugins/arLettresPlugin/css/min.css', 'last', ['media' => 'all']);
     }
 
     public function initialize()
     {
         // Run the class method contextLoadFactories defined above once Symfony
         // is done loading the internal framework factories.
-        $this->dispatcher->connect('context.load_factories', array($this, 'contextLoadFactories'));
+        $this->dispatcher->connect('context.load_factories', [$this, 'contextLoadFactories']);
 
         // This allows us to override the application decorators.
         $decoratorDirs = sfConfig::get('sf_decorator_dirs');
-        $decoratorDirs[] = $this->rootDir . '/templates';
+        $decoratorDirs[] = $this->rootDir.'/templates';
         sfConfig::set('sf_decorator_dirs', $decoratorDirs);
 
         // This allows us to override the contents of the application modules.
         $moduleDirs = sfConfig::get('sf_module_dirs');
-        $moduleDirs[$this->rootDir . '/modules'] = false;
+        $moduleDirs[$this->rootDir.'/modules'] = false;
         sfConfig::set('sf_module_dirs', $moduleDirs);
     }
 }

--- a/plugins/arLettresPlugin/templates/_header.php
+++ b/plugins/arLettresPlugin/templates/_header.php
@@ -1,49 +1,49 @@
-<?php echo get_component('default', 'updateCheck') ?>
+<?php echo get_component('default', 'updateCheck'); ?>
 
-<?php echo get_component('default', 'privacyMessage') ?>
+<?php echo get_component('default', 'privacyMessage'); ?>
 
-<?php if ($sf_user->isAdministrator() && (string)QubitSetting::getByName('siteBaseUrl') === ''): ?>
+<?php if ($sf_user->isAdministrator() && '' === (string) QubitSetting::getByName('siteBaseUrl')) { ?>
   <div class="site-warning">
-    <?php echo link_to(__('Please configure your site base URL'), 'settings/siteInformation', array('rel' => 'home', 'title' => __('Home'))) ?>
+    <?php echo link_to(__('Please configure your site base URL'), 'settings/siteInformation', ['rel' => 'home', 'title' => __('Home')]); ?>
   </div>
-<?php endif; ?>
+<?php } ?>
 
 <header id="top-bar">
 
-  <?php if (sfConfig::get('app_toggleLogo')): ?>
-    <?php echo link_to(image_tag('/plugins/arLettresPlugin/images/logo.svg'), '@homepage', array('class' => 'navbar-brand navbar-logo', 'id' => 'logo', 'rel' => 'home')) ?>
-  <?php endif; ?>
+  <?php if (sfConfig::get('app_toggleLogo')) { ?>
+    <?php echo link_to(image_tag('/plugins/arLettresPlugin/images/logo.svg'), '@homepage', ['class' => 'navbar-brand navbar-logo', 'id' => 'logo', 'rel' => 'home']); ?>
+  <?php } ?>
 
-  <?php if (sfConfig::get('app_toggleTitle')): ?>
+  <?php if (sfConfig::get('app_toggleTitle')) { ?>
     <h1 id="site-name">
-      <?php echo link_to('<span>'.esc_specialchars(sfConfig::get('app_siteTitle')).'</span>', '@homepage', array('rel' => 'home', 'title' => __('Home'))) ?>
+      <?php echo link_to('<span>'.esc_specialchars(sfConfig::get('app_siteTitle')).'</span>', '@homepage', ['rel' => 'home', 'title' => __('Home')]); ?>
     </h1>
-  <?php endif; ?>
+  <?php } ?>
 
   <nav>
 
-    <?php echo get_component('menu', 'userMenu') ?>  <!--- button login --->
+    <?php echo get_component('menu', 'userMenu'); ?>  <!--- button login --->
 
-    <?php echo get_component('menu', 'quickLinksMenu') ?>
+    <?php echo get_component('menu', 'quickLinksMenu'); ?>
 
-    <?php if (sfConfig::get('app_toggleLanguageMenu')): ?>
-      <?php echo get_component('menu', 'changeLanguageMenu') ?>
-    <?php endif; ?>
+    <?php if (sfConfig::get('app_toggleLanguageMenu')) { ?>
+      <?php echo get_component('menu', 'changeLanguageMenu'); ?>
+    <?php } ?>
 
-    <?php echo get_component('menu', 'clipboardMenu') ?>
+    <?php echo get_component('menu', 'clipboardMenu'); ?>
 
-    <?php echo get_component('menu', 'mainMenu', array('sf_cache_key' => $sf_user->getCulture().$sf_user->getUserID())) ?>
+    <?php echo get_component('menu', 'mainMenu', ['sf_cache_key' => $sf_user->getCulture().$sf_user->getUserID()]); ?>
 
   </nav>
 
   <div id="search-bar">
 
-    <?php echo get_component('menu', 'browseMenu', array('sf_cache_key' => $sf_user->getCulture().$sf_user->getUserID())) ?>
+    <?php echo get_component('menu', 'browseMenu', ['sf_cache_key' => $sf_user->getCulture().$sf_user->getUserID()]); ?>
 
-    <?php echo get_component('search', 'box') ?>
+    <?php echo get_component('search', 'box'); ?>
 
   </div>
 
-  <?php echo get_component_slot('header') ?>
+  <?php echo get_component_slot('header'); ?>
 
 </header>

--- a/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
+++ b/plugins/arOaiPlugin/lib/arOaiPluginComponent.class.php
@@ -96,12 +96,14 @@ abstract class arOaiPluginComponent extends sfComponent
         // Get set if one has been named
         if ('' != $this->set) {
             $presetOptions['set'] = QubitOai::getMatchingOaiSet($this->set);
+            $presetOptions['setSpec'] = $this->set;
         }
 
         $options = array_merge($presetOptions, $options);
+        $options['metadataPrefix'] = $this->metadataPrefix;
 
         // Get the records according to the limit dates and collection
-        $update = QubitInformationObject::getUpdatedRecords($options);
+        $update = QubitOaiDeletedRecord::getRecords($options);
 
         $this->publishedRecords = $update['data'];
         $this->remaining = $update['remaining'];
@@ -154,5 +156,19 @@ abstract class arOaiPluginComponent extends sfComponent
         $format = self::parseXmlFormatFromMetadataPrefix($metadataPrefix);
 
         include QubitInformationObjectXmlCache::resourceExportFilePath($resource, $format, true);
+    }
+
+    public static function isDeletedRecord($record)
+    {
+        return is_object($record) && method_exists($record, 'isDeleted') && $record->isDeleted();
+    }
+
+    public static function getRecordSetSpec($record)
+    {
+        if (self::isDeletedRecord($record)) {
+            return $record->getSetSpec();
+        }
+
+        return $record->getCollectionRoot()->getOaiIdentifier();
     }
 }

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/getRecordComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/getRecordComponent.class.php
@@ -30,8 +30,17 @@ class arOaiPluginGetRecordComponent extends arOaiPluginComponent
         $oaiLocalIdentifierId = QubitOai::getOaiIdNumber($request->identifier);
         $this->record = QubitInformationObject::getRecordByOaiID($oaiLocalIdentifierId);
 
+        if (
+            !isset($this->record)
+            || !isset($this->record->parent)
+            || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID != $this->record->getPublicationStatus()->statusId
+            || !QubitAcl::check($this->record, 'read')
+        ) {
+            $this->record = QubitOaiDeletedRecord::getActiveByOaiLocalIdentifier($oaiLocalIdentifierId, $request->metadataPrefix);
+        }
+
         // If metadata requested is EAD and file doesn't exist, redirect to error response as EAD can take a long time to dynamically generate
-        if ('oai_ead' == $request->metadataPrefix && !arOaiPluginComponent::cachedMetadataExists($this->record, $request->metadataPrefix)) {
+        if (!arOaiPluginComponent::isDeletedRecord($this->record) && 'oai_ead' == $request->metadataPrefix && !arOaiPluginComponent::cachedMetadataExists($this->record, $request->metadataPrefix)) {
             $this->errorCode = 'cannotDisseminateFormat';
             $this->errorMsg = 'The metadata format identified by the value given for the metadataPrefix argument is not supported by the item or by the repository.';
         } else {

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/identifyComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/identifyComponent.class.php
@@ -35,7 +35,7 @@ class arOaiPluginIdentifyComponent extends arOaiPluginComponent
 
         $this->baseUrl = QubitSetting::getByName('siteBaseUrl')->getValue(['sourceCulture' => true]);
         $this->granularity = 'YYYY-MM-DDThh:mm:ssZ';
-        $this->deletedRecord = 'no';
+        $this->deletedRecord = 'persistent';
         $this->compression = 'gzip';
 
         $this->setRequestAttributes($request);

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/indexAction.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/indexAction.class.php
@@ -142,10 +142,17 @@ class arOaiPluginIndexAction extends sfAction
                     || QubitTerm::PUBLICATION_STATUS_PUBLISHED_ID != $resource->getPublicationStatus()->statusId
                     || !QubitAcl::check($resource, 'read')
                 ) {
-                    $request->setParameter('errorCode', 'idDoesNotExist');
-                    $request->setParameter('errorMsg', 'The value of the identifier argument is unknown or illegal in this repository.');
+                    $deletedRecord = QubitOaiDeletedRecord::getActiveByOaiLocalIdentifier(
+                        QubitOai::getOaiIdNumber($this->request->identifier),
+                        $this->request->metadataPrefix ?: null
+                    );
 
-                    $this->forward('arOaiPlugin', 'error');
+                    if (null === $deletedRecord) {
+                        $request->setParameter('errorCode', 'idDoesNotExist');
+                        $request->setParameter('errorMsg', 'The value of the identifier argument is unknown or illegal in this repository.');
+
+                        $this->forward('arOaiPlugin', 'error');
+                    }
                 }
             }
 

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listRecordsComponent.class.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/actions/listRecordsComponent.class.php
@@ -37,6 +37,10 @@ class arOaiPluginListRecordsComponent extends arOaiPluginComponent
         $this->identifiersWithMissingCacheFiles = [];
         if ('oai_ead' == $request->metadataPrefix && count($this->publishedRecords)) {
             foreach ($this->publishedRecords as $resource) {
+                if (arOaiPluginComponent::isDeletedRecord($resource)) {
+                    continue;
+                }
+
                 if (!arOaiPluginComponent::cachedMetadataExists($resource, 'oai_ead')) {
                     array_push($this->identifiersWithMissingCacheFiles, $resource->getOaiIdentifier());
                 }

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_getRecord.xml.php
@@ -3,10 +3,17 @@
 <?php } else { ?>
   <GetRecord>
     <record>
+    <?php if (arOaiPluginComponent::isDeletedRecord($record)) { ?>
+      <header status="deleted">
+        <identifier><?php echo $record->getOaiIdentifier(); ?></identifier>
+        <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt()); ?></datestamp>
+        <setSpec><?php echo arOaiPluginComponent::getRecordSetSpec($record); ?></setSpec>
+      </header>
+    <?php } else { ?>
       <header>
         <identifier><?php echo $record->getOaiIdentifier(); ?></identifier>
         <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt()); ?></datestamp>
-        <setSpec><?php echo $record->getCollectionRoot()->getOaiIdentifier(); ?></setSpec>
+        <setSpec><?php echo arOaiPluginComponent::getRecordSetSpec($record); ?></setSpec>
       </header>
       <metadata>
         <?php if ('oai_dc' == $metadataPrefix && !arOaiPluginComponent::checkDisplayCachedMetadata($record, $metadataPrefix)) { ?>
@@ -18,6 +25,7 @@
       <?php if (count($record->digitalObjectsRelatedByobjectId)) { ?>
         <?php include '_about.xml.php'; ?>
       <?php } ?>
+    <?php } ?>
     </record>
   </GetRecord>
 <?php } ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listIdentifiers.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listIdentifiers.xml.php
@@ -3,10 +3,10 @@
 <?php } else { ?>
   <ListIdentifiers>
 <?php foreach ($publishedRecords as $record) { ?>
-    <header>
+    <header<?php echo arOaiPluginComponent::isDeletedRecord($record) ? ' status="deleted"' : ''; ?>>
       <identifier><?php echo $record->getOaiIdentifier(); ?></identifier>
       <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt()); ?></datestamp>
-      <setSpec><?php echo $record->getCollectionRoot()->getOaiIdentifier(); ?></setSpec>
+      <setSpec><?php echo arOaiPluginComponent::getRecordSetSpec($record); ?></setSpec>
     </header>
 <?php } ?>
   <?php if ($remaining > 0) { ?>

--- a/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
+++ b/plugins/arOaiPlugin/modules/arOaiPlugin/templates/_listRecords.xml.php
@@ -3,12 +3,20 @@
 <?php } else { ?>
   <ListRecords>
   <?php foreach ($publishedRecords as $record) { ?>
-    <?php if (QubitAcl::check($record, 'read') && false === array_search($record->getOaiIdentifier(), $identifiersWithMissingCacheFiles)) { ?>
+    <?php if (arOaiPluginComponent::isDeletedRecord($record)) { ?>
+      <record>
+        <header status="deleted">
+          <identifier><?php echo $record->getOaiIdentifier(); ?></identifier>
+          <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt()); ?></datestamp>
+          <setSpec><?php echo arOaiPluginComponent::getRecordSetSpec($record); ?></setSpec>
+        </header>
+      </record>
+    <?php } elseif (QubitAcl::check($record, 'read') && false === array_search($record->getOaiIdentifier(), $identifiersWithMissingCacheFiles)) { ?>
       <record>
         <header>
           <identifier><?php echo $record->getOaiIdentifier(); ?></identifier>
           <datestamp><?php echo QubitOai::getDate($record->getUpdatedAt()); ?></datestamp>
-          <setSpec><?php echo $record->getCollectionRoot()->getOaiIdentifier(); ?></setSpec>
+          <setSpec><?php echo arOaiPluginComponent::getRecordSetSpec($record); ?></setSpec>
         </header>
         <metadata>
           <?php if ('oai_dc' == $metadataPrefix && !arOaiPluginComponent::checkDisplayCachedMetadata($record, $metadataPrefix)) { ?>

--- a/scripts/atom_db_schema_snapshot.sh
+++ b/scripts/atom_db_schema_snapshot.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/atom_db_schema_snapshot.sh [--mode compose|mysql] [--env-file PATH]
+                                     [--compose-service NAME]
+                                     [--db NAME] [--user USER] [--pass PASS]
+                                     [--host HOST] [--port PORT]
+
+Outputs a deterministic TSV snapshot of:
+  - columns (INFORMATION_SCHEMA.COLUMNS)
+  - indexes (INFORMATION_SCHEMA.STATISTICS)
+  - foreign keys (INFORMATION_SCHEMA.KEY_COLUMN_USAGE)
+
+Defaults:
+  - If --env-file is omitted and docker/etc/environment exists, it is loaded.
+  - --mode defaults to compose.
+  - --compose-service defaults to percona.
+
+Examples:
+  # Local docker (preferred): uses docker compose exec into percona
+  export COMPOSE_FILE="$PWD/docker/docker-compose.dev.yml:$PWD/docker/docker-compose.override.arm.yml"
+  scripts/atom_db_schema_snapshot.sh --mode compose > /tmp/atom-schema.local.tsv
+
+  # Direct MySQL (e.g. prod host): requires mysql client installed
+  scripts/atom_db_schema_snapshot.sh --mode mysql --host 127.0.0.1 --port 3306 \
+    --db atom --user atom --pass 'secret' > /tmp/atom-schema.prod.tsv
+EOF
+}
+
+mode="compose"
+env_file=""
+compose_service="percona"
+
+db="${MYSQL_DATABASE:-}"
+user="${MYSQL_USER:-}"
+pass="${MYSQL_PASSWORD:-}"
+host="127.0.0.1"
+port="3306"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --mode)
+      mode="${2:-}"; shift 2
+      ;;
+    --env-file)
+      env_file="${2:-}"; shift 2
+      ;;
+    --compose-service)
+      compose_service="${2:-}"; shift 2
+      ;;
+    --db)
+      db="${2:-}"; shift 2
+      ;;
+    --user)
+      user="${2:-}"; shift 2
+      ;;
+    --pass)
+      pass="${2:-}"; shift 2
+      ;;
+    --host)
+      host="${2:-}"; shift 2
+      ;;
+    --port)
+      port="${2:-}"; shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ -z "$env_file" && -f "docker/etc/environment" ]]; then
+  env_file="docker/etc/environment"
+fi
+
+if [[ -n "$env_file" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  source "$env_file"
+  set +a
+fi
+
+db="${db:-${MYSQL_DATABASE:-}}"
+user="${user:-${MYSQL_USER:-}}"
+pass="${pass:-${MYSQL_PASSWORD:-}}"
+
+if [[ -z "$db" || -z "$user" || -z "$pass" ]]; then
+  echo "Missing connection params. Need db/user/pass (set via --db/--user/--pass or env file)." >&2
+  exit 2
+fi
+
+run_mysql() {
+  local sql="$1"
+
+  if [[ "$mode" == "compose" ]]; then
+    docker compose exec -T "$compose_service" \
+      mysql --batch --raw --silent --skip-column-names \
+        -u"$user" -p"$pass" "$db" -e "$sql"
+    return
+  fi
+
+  if [[ "$mode" == "mysql" ]]; then
+    mysql --protocol=tcp --batch --raw --silent --skip-column-names \
+      -h "$host" -P "$port" -u"$user" -p"$pass" "$db" -e "$sql"
+    return
+  fi
+
+  echo "Invalid --mode: $mode (expected: compose|mysql)" >&2
+  exit 2
+}
+
+generated_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+echo "# atom_db_schema_snapshot v1"
+echo "# generated_at_utc\t${generated_at}"
+echo -e "# mode\t${mode}"
+if [[ "$mode" == "compose" ]]; then
+  echo -e "# compose_service\t${compose_service}"
+else
+  echo -e "# host\t${host}"
+  echo -e "# port\t${port}"
+fi
+echo -e "# db\t${db}"
+echo
+
+echo "# columns"
+echo -e "table\tcolumn\tcolumn_type\tis_nullable\tdefault\textra\tcollation\tcolumn_key"
+run_mysql "
+  SELECT
+    TABLE_NAME,
+    COLUMN_NAME,
+    COLUMN_TYPE,
+    IS_NULLABLE,
+    IFNULL(COLUMN_DEFAULT, '<NULL>'),
+    IFNULL(EXTRA, ''),
+    IFNULL(COLLATION_NAME, ''),
+    IFNULL(COLUMN_KEY, '')
+  FROM INFORMATION_SCHEMA.COLUMNS
+  WHERE TABLE_SCHEMA = DATABASE()
+  ORDER BY TABLE_NAME, ORDINAL_POSITION;
+"
+echo
+
+echo "# indexes"
+echo -e "table\tindex_name\tnon_unique\tseq_in_index\tcolumn\tcollation\tsub_part\tindex_type"
+run_mysql "
+  SELECT
+    TABLE_NAME,
+    INDEX_NAME,
+    NON_UNIQUE,
+    SEQ_IN_INDEX,
+    COLUMN_NAME,
+    IFNULL(COLLATION, ''),
+    IFNULL(SUB_PART, ''),
+    IFNULL(INDEX_TYPE, '')
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE TABLE_SCHEMA = DATABASE()
+  ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX;
+"
+echo
+
+echo "# foreign_keys"
+echo -e "table\tconstraint\tcolumn\treferenced_table\treferenced_column"
+run_mysql "
+  SELECT
+    TABLE_NAME,
+    CONSTRAINT_NAME,
+    COLUMN_NAME,
+    REFERENCED_TABLE_NAME,
+    REFERENCED_COLUMN_NAME
+  FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE
+  WHERE TABLE_SCHEMA = DATABASE()
+    AND REFERENCED_TABLE_NAME IS NOT NULL
+  ORDER BY TABLE_NAME, CONSTRAINT_NAME, ORDINAL_POSITION;
+"
+

--- a/scripts/atom_nginx_traffic_stats.py
+++ b/scripts/atom_nginx_traffic_stats.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Summarize AtoM nginx access logs for traffic-management reporting."""
+
+from __future__ import annotations
+
+import argparse
+import gzip
+import json
+import re
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+MONTH = {
+    "Jan": "01",
+    "Feb": "02",
+    "Mar": "03",
+    "Apr": "04",
+    "May": "05",
+    "Jun": "06",
+    "Jul": "07",
+    "Aug": "08",
+    "Sep": "09",
+    "Oct": "10",
+    "Nov": "11",
+    "Dec": "12",
+}
+
+LINE_RE = re.compile(
+    r'^(?P<ip>\S+) \S+ \S+ \[(?P<dt>[^:]+):(?P<time>[^ ]+) [^\]]+\] '
+    r'"(?P<method>\S+) (?P<uri>[^" ]*) (?P<proto>[^"]*)" '
+    r'(?P<status>\d{3}) (?P<bytes>\S+) "(?P<ref>[^"]*)" "(?P<ua>[^"]*)"'
+)
+
+BOT_RE = re.compile(
+    r"bot|crawler|spider|slurp|bingpreview|googleother|bytespider|ahrefs|"
+    r"semrush|mj12|dotbot|petalbot|dataforseo|blexbot",
+    re.I,
+)
+
+KNOWN_BOT_RE = re.compile(
+    r"Googlebot|bingbot|BingPreview|GPTBot|ClaudeBot|Amazonbot|AhrefsBot|"
+    r"SemrushBot|MJ12bot|DotBot|DataForSeoBot|BLEXBot|Bytespider|PetalBot|"
+    r"GoogleOther",
+    re.I,
+)
+
+
+def day_from_nginx_date(value: str) -> str:
+    day, month, year = value.split("/")
+    return f"{year}-{MONTH[month]}-{int(day):02d}"
+
+
+def route_for(uri: str) -> str:
+    low = uri.lower()
+
+    if "informationobject/fullwidthtreeview" in low:
+        return "tree"
+
+    if "informationobject/browse" in low:
+        return "browse"
+
+    if ";oai" in low or ("verb=" in low and "metadataprefix" in low):
+        return "oai"
+
+    if "sf_format=xml" in low or "/downloads/exports/ead/" in low or low.endswith(".ead.xml"):
+        return "xml_ead"
+
+    if "/search" in low:
+        return "search"
+
+    if low.startswith("/index.php"):
+        return "other_index"
+
+    if re.search(r"\.(css|js|png|jpg|jpeg|gif|svg|ico|woff|woff2|ttf|map)(\?|$)", low):
+        return "static"
+
+    return "other"
+
+
+def is_unil_ip(ip: str) -> bool:
+    return ip.startswith("130.223.") or ip.startswith("2001:620:610:")
+
+
+def open_log(path: Path):
+    if path.suffix == ".gz":
+        return gzip.open(path, "rt", errors="replace")
+
+    return path.open("rt", errors="replace")
+
+
+def summarize(paths: list[Path]) -> dict:
+    daily: defaultdict[str, Counter] = defaultdict(Counter)
+    top_429_ip: Counter = Counter()
+    top_429_ua: Counter = Counter()
+    top_429_uri: Counter = Counter()
+    top_browse_ip: Counter = Counter()
+    files_used: list[str] = []
+    total_lines = 0
+    parsed_lines = 0
+    first_day = None
+    last_day = None
+
+    for path in sorted(paths, key=lambda item: str(item)):
+        used = False
+
+        with open_log(path) as handle:
+            for line in handle:
+                total_lines += 1
+                match = LINE_RE.match(line)
+
+                if not match:
+                    continue
+
+                parsed_lines += 1
+                used = True
+                data = match.groupdict()
+                day = day_from_nginx_date(data["dt"])
+                status = int(data["status"])
+                uri = data["uri"]
+                ua = data["ua"]
+                ip = data["ip"]
+                route = route_for(uri)
+                is_bot = bool(BOT_RE.search(ua))
+                is_known_bot = bool(KNOWN_BOT_RE.search(ua))
+                is_unil = is_unil_ip(ip)
+
+                first_day = min(first_day, day) if first_day else day
+                last_day = max(last_day, day) if last_day else day
+
+                counter = daily[day]
+                counter["requests"] += 1
+                counter[f"{status // 100}xx"] += 1
+                counter[f"status_{status}"] += 1
+                counter[f"route_{route}"] += 1
+                counter["bot_like"] += int(is_bot)
+                counter["known_bot"] += int(is_known_bot)
+                counter["unil"] += int(is_unil)
+                counter["public"] += int(not is_unil)
+
+                if status == 429:
+                    counter["429"] += 1
+                    counter[f"429_{route}"] += 1
+                    counter["429_bot_like"] += int(is_bot)
+                    counter["429_unil"] += int(is_unil)
+                    counter["429_public"] += int(not is_unil)
+                    top_429_ip[ip] += 1
+                    top_429_ua[ua[:160]] += 1
+                    top_429_uri[uri[:180]] += 1
+
+                if route == "browse":
+                    top_browse_ip[ip] += 1
+
+        if used:
+            files_used.append(str(path))
+
+    periods = {
+        "may06_11_before_ead_work": ("2026-05-06", "2026-05-11"),
+        "may12_14_deploy_refresh_period": ("2026-05-12", "2026-05-14"),
+        "may15_19_quieter_period": ("2026-05-15", "2026-05-19"),
+    }
+    period_stats = {}
+
+    for name, (start, end) in periods.items():
+        aggregate: Counter = Counter()
+
+        for day, counter in daily.items():
+            if start <= day <= end:
+                aggregate.update(counter)
+
+        period_stats[name] = dict(aggregate)
+
+    return {
+        "files_used": files_used,
+        "first_day": first_day,
+        "last_day": last_day,
+        "total_lines": total_lines,
+        "parsed_lines": parsed_lines,
+        "daily": {day: dict(daily[day]) for day in sorted(daily)},
+        "periods": period_stats,
+        "top_429_ip": top_429_ip.most_common(20),
+        "top_429_ua": top_429_ua.most_common(12),
+        "top_429_uri": top_429_uri.most_common(20),
+        "top_browse_ip": top_browse_ip.most_common(20),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("paths", nargs="+", type=Path)
+    args = parser.parse_args()
+
+    print(json.dumps(summarize(args.paths), indent=2, sort_keys=True))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/prod_host_legacy_package_cleanup_20260702.sh
+++ b/scripts/prod_host_legacy_package_cleanup_20260702.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "Run as root on atom-archives.unil.ch." >&2
+  exit 1
+fi
+
+if [[ "$(hostname -f 2>/dev/null || hostname)" != "atom-archives" ]]; then
+  echo "Refusing to run: expected host atom-archives." >&2
+  exit 1
+fi
+
+export COMPOSE_FILE=/home/deployer/atom/docker/docker-compose.prod.yml
+stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+evidence="/home/deployer/atom/host-package-cleanup-tenable-${stamp}.txt"
+
+targets=(
+  ffmpeg
+  imagemagick
+  imagemagick-6-common
+  imagemagick-6.q16
+  libmagickcore-6.q16-6
+  libmagickcore-6.q16-6-extra
+  libmagickwand-6.q16-6
+  nodejs
+  nodejs-doc
+  elasticsearch
+  openjdk-11-jre-headless
+)
+
+{
+  echo "# AtoM host legacy package cleanup evidence"
+  echo "timestamp=${stamp}"
+  echo "host=$(hostname -f 2>/dev/null || hostname)"
+  echo
+  echo "## Docker stack before package cleanup"
+  cd /home/deployer/atom
+  docker compose ps
+  echo
+  echo "## Installed package versions"
+  dpkg-query -W -f='${binary:Package}\t${Version}\t${Status}\n' \
+    "${targets[@]}" fop node-less ca-certificates-java 2>/dev/null || true
+  echo
+  echo "## Manual package marks"
+  apt-mark showmanual | grep -E '^(ffmpeg|imagemagick|nodejs|elasticsearch|openjdk-11-jre-headless)$' || true
+  echo
+  echo "## Purge simulation"
+  apt-get -s purge "${targets[@]}"
+} | tee "$evidence"
+
+if [[ "${1:-}" != "--apply" ]]; then
+  echo
+  echo "Dry run only. Evidence written to: $evidence"
+  echo "Review the purge simulation, confirm a VM snapshot/rollback plan, then rerun with --apply."
+  exit 0
+fi
+
+echo
+echo "Applying explicit purge list. Autoremove is intentionally not run in this step."
+apt-get purge -y "${targets[@]}"
+
+echo
+echo "Post-cleanup Docker stack:"
+cd /home/deployer/atom
+docker compose ps
+
+echo
+echo "Post-cleanup production health:"
+./scripts/prod_health_check.sh
+
+echo
+echo "Review remaining unused dependencies separately with:"
+echo "  apt-get -s autoremove --purge"

--- a/scripts/prod_host_nginx_crawler_hardening_20260430.sh
+++ b/scripts/prod_host_nginx_crawler_hardening_20260430.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(id -u)" != "0" ]]; then
+  echo "Run as root, e.g. sudo bash $0" >&2
+  exit 1
+fi
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+nginx_conf="/etc/nginx/nginx.conf"
+atom_vhost="/etc/nginx/sites-available/atom"
+
+cp -a "$nginx_conf" "$nginx_conf.bak-$ts"
+cp -a "$atom_vhost" "$atom_vhost.bak-$ts"
+
+python3 - <<'PY'
+from pathlib import Path
+
+nginx_conf = Path("/etc/nginx/nginx.conf")
+atom_vhost = Path("/etc/nginx/sites-available/atom")
+
+text = nginx_conf.read_text()
+needle = "\tlimit_req_zone $binary_remote_addr zone=atom_browse_rl:10m rate=5r/s;\n"
+insert = (
+    "\tlimit_req_zone $binary_remote_addr zone=atom_browse_rl:10m rate=5r/s;\n"
+    "\tlimit_req_zone $server_name zone=atom_browse_global_rl:1m rate=10r/s;\n"
+    "\tlimit_req_zone $binary_remote_addr zone=atom_tree_rl:10m rate=12r/m;\n"
+    "\tlimit_conn_zone $binary_remote_addr zone=atom_tree_conn:10m;\n"
+)
+if "zone=atom_browse_global_rl" not in text:
+    if needle not in text:
+        raise SystemExit("Cannot find atom_browse_rl zone in /etc/nginx/nginx.conf")
+    text = text.replace(needle, insert, 1)
+nginx_conf.write_text(text)
+
+text = atom_vhost.read_text()
+
+old_browse = """location ^~ /index.php/informationobject/browse {
+  limit_req zone=atom_browse_rl burst=30 nodelay;
+  limit_req_status 429;
+
+  proxy_pass http://127.0.0.1:8081;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Port 443;
+  proxy_read_timeout 300;
+  proxy_send_timeout 300;
+  proxy_redirect off;
+}
+"""
+
+new_browse = """location ^~ /index.php/informationobject/browse {
+  limit_req zone=atom_browse_rl burst=30 nodelay;
+  limit_req zone=atom_browse_global_rl burst=20 nodelay;
+  limit_req_status 429;
+
+  proxy_pass http://127.0.0.1:8081;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Port 443;
+  proxy_read_timeout 300;
+  proxy_send_timeout 300;
+  proxy_redirect off;
+}
+
+location ^~ /informationobject/browse {
+  limit_req zone=atom_browse_rl burst=30 nodelay;
+  limit_req zone=atom_browse_global_rl burst=20 nodelay;
+  limit_req_status 429;
+
+  proxy_pass http://127.0.0.1:8081;
+  proxy_set_header Host $host;
+  proxy_set_header X-Real-IP $remote_addr;
+  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+  proxy_set_header X-Forwarded-Proto $scheme;
+  proxy_set_header X-Forwarded-Host $host;
+  proxy_set_header X-Forwarded-Port 443;
+  proxy_read_timeout 300;
+  proxy_send_timeout 300;
+  proxy_redirect off;
+}
+"""
+
+if "zone=atom_browse_global_rl" not in text:
+    if old_browse not in text:
+        raise SystemExit("Cannot find expected browse location in /etc/nginx/sites-available/atom")
+    text = text.replace(old_browse, new_browse, 1)
+
+tree_location = """  location ~ /informationobject/fullWidthTreeView {
+    limit_req zone=atom_tree_rl burst=4 nodelay;
+    limit_req_status 429;
+    limit_conn atom_tree_conn 1;
+
+    proxy_pass http://127.0.0.1:8081;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port 443;
+    proxy_read_timeout 300;
+    proxy_send_timeout 300;
+    proxy_redirect off;
+  }
+
+"""
+
+if "zone=atom_tree_rl" not in text:
+    marker = "  location / {\n"
+    if marker not in text:
+        raise SystemExit("Cannot find location / marker in /etc/nginx/sites-available/atom")
+    text = text.replace(marker, tree_location + marker, 1)
+
+atom_vhost.write_text(text)
+PY
+
+nginx -t
+systemctl reload nginx
+
+echo "Host nginx crawler hardening applied."
+echo "Backups:"
+echo "  $nginx_conf.bak-$ts"
+echo "  $atom_vhost.bak-$ts"

--- a/scripts/prod_host_nginx_print_browse_guard_20260624.sh
+++ b/scripts/prod_host_nginx_print_browse_guard_20260624.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(id -u)" != "0" ]]; then
+  echo "Run as root, e.g. sudo bash $0" >&2
+  exit 1
+fi
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+nginx_conf="/etc/nginx/nginx.conf"
+atom_vhost="/etc/nginx/sites-available/atom"
+nginx_backup="$nginx_conf.bak-print-browse-guard-$ts"
+vhost_backup="$atom_vhost.bak-print-browse-guard-$ts"
+
+cp -a "$nginx_conf" "$nginx_backup"
+cp -a "$atom_vhost" "$vhost_backup"
+
+restore() {
+  cp -a "$nginx_backup" "$nginx_conf"
+  cp -a "$vhost_backup" "$atom_vhost"
+}
+
+python3 - <<'PY'
+from pathlib import Path
+
+nginx_conf = Path("/etc/nginx/nginx.conf")
+atom_vhost = Path("/etc/nginx/sites-available/atom")
+
+text = nginx_conf.read_text()
+
+if "$atom_public_print_browse" not in text:
+    marker = """\tlimit_req_zone $atom_public_client_key zone=atom_browse_rl:10m rate=5r/s;\n"""
+    guard = """\t# Drop public print-browse scraper bursts before they reach Docker/PHP.\n\tmap "$atom_unil_client:$arg_media:$uri" $atom_public_print_browse {\n\t\tdefault 0;\n\t\t~^0:print:/index\\.php/informationobject/browse 1;\n\t\t~^0:print:/informationobject/browse 1;\n\t}\n\n"""
+    if marker not in text:
+        raise SystemExit("Expected host nginx browse zone marker not found")
+    text = text.replace(marker, guard + marker, 1)
+    nginx_conf.write_text(text)
+
+text = atom_vhost.read_text()
+
+if "atom_public_print_browse" not in text:
+    marker = "  client_max_body_size 72M;\n\n"
+    guard = """  if ($atom_public_print_browse) {\n    return 444;\n  }\n\n"""
+    if marker not in text:
+        raise SystemExit("Expected host nginx vhost insertion marker not found")
+    text = text.replace(marker, marker + guard, 1)
+    atom_vhost.write_text(text)
+PY
+
+if ! nginx -t; then
+  echo "nginx -t failed; restoring backups" >&2
+  restore
+  nginx -t || true
+  exit 1
+fi
+
+systemctl reload nginx
+
+echo "Host nginx print-browse guard applied."
+echo "Backups:"
+echo "  $nginx_backup"
+echo "  $vhost_backup"

--- a/scripts/prod_host_nginx_security_headers_20260430.sh
+++ b/scripts/prod_host_nginx_security_headers_20260430.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(id -u)" != "0" ]]; then
+  echo "Run as root, e.g. sudo bash $0" >&2
+  exit 1
+fi
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+atom_vhost="/etc/nginx/sites-available/atom"
+
+cp -a "$atom_vhost" "$atom_vhost.bak-$ts"
+
+python3 - <<'PY'
+from pathlib import Path
+
+atom_vhost = Path("/etc/nginx/sites-available/atom")
+text = atom_vhost.read_text()
+
+headers = """  add_header X-Content-Type-Options "nosniff" always;
+  add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+  add_header Permissions-Policy "accelerometer=(), autoplay=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()" always;
+  add_header Strict-Transport-Security "max-age=3600" always;
+"""
+
+if "add_header X-Content-Type-Options" not in text:
+    marker = "  fastcgi_hide_header X-Powered-By;\n"
+    if marker not in text:
+        raise SystemExit("Cannot find header insertion marker in /etc/nginx/sites-available/atom")
+    text = text.replace(marker, marker + headers, 1)
+
+atom_vhost.write_text(text)
+PY
+
+nginx -t
+systemctl reload nginx
+
+echo "Host nginx security headers applied."
+echo "Backup:"
+echo "  $atom_vhost.bak-$ts"

--- a/scripts/prod_host_nginx_unil_rate_limit_cleanup_20260519.sh
+++ b/scripts/prod_host_nginx_unil_rate_limit_cleanup_20260519.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$(id -u)" != "0" ]]; then
+  echo "Run as root, e.g. sudo bash $0" >&2
+  exit 1
+fi
+
+ts="$(date -u +%Y%m%dT%H%M%SZ)"
+nginx_conf="/etc/nginx/nginx.conf"
+atom_vhost="/etc/nginx/sites-available/atom"
+nginx_backup="$nginx_conf.bak-unil-rate-limits-$ts"
+vhost_backup="$atom_vhost.bak-unil-rate-limits-$ts"
+
+cp -a "$nginx_conf" "$nginx_backup"
+cp -a "$atom_vhost" "$vhost_backup"
+
+restore() {
+  cp -a "$nginx_backup" "$nginx_conf"
+  cp -a "$vhost_backup" "$atom_vhost"
+}
+
+python3 - <<'PY'
+from pathlib import Path
+
+nginx_conf = Path("/etc/nginx/nginx.conf")
+atom_vhost = Path("/etc/nginx/sites-available/atom")
+
+text = nginx_conf.read_text()
+
+old_zones = """\tlimit_req_zone $binary_remote_addr zone=atom_browse_rl:10m rate=5r/s;
+\tlimit_req_zone $server_name zone=atom_browse_global_rl:1m rate=10r/s;
+\tlimit_req_zone $binary_remote_addr zone=atom_tree_rl:10m rate=12r/m;
+\tlimit_conn_zone $binary_remote_addr zone=atom_tree_conn:10m;
+"""
+
+new_zones = """\t# Split public and UNIL traffic so public crawler bursts do not consume
+\t# the same host-edge browse/tree budgets as local UNIL users.
+\tgeo $atom_unil_client {
+\t\tdefault 0;
+\t\t130.223.0.0/16 1;
+\t\t2001:620:610::/48 1;
+\t}
+
+\tmap $atom_unil_client $atom_public_client_key {
+\t\t0 $binary_remote_addr;
+\t\t1 "";
+\t}
+
+\tmap $atom_unil_client $atom_unil_client_key {
+\t\t0 "";
+\t\t1 $binary_remote_addr;
+\t}
+
+\tmap $atom_unil_client $atom_public_global_key {
+\t\t0 $server_name;
+\t\t1 "";
+\t}
+
+\tmap $atom_unil_client $atom_unil_global_key {
+\t\t0 "";
+\t\t1 $server_name;
+\t}
+
+\tlimit_req_zone $atom_public_client_key zone=atom_browse_rl:10m rate=5r/s;
+\tlimit_req_zone $atom_unil_client_key zone=atom_browse_unil_rl:10m rate=15r/s;
+\tlimit_req_zone $atom_public_global_key zone=atom_browse_global_rl:1m rate=10r/s;
+\tlimit_req_zone $atom_unil_global_key zone=atom_browse_unil_global_rl:1m rate=30r/s;
+\tlimit_req_zone $atom_public_client_key zone=atom_tree_rl:10m rate=12r/m;
+\tlimit_req_zone $atom_unil_client_key zone=atom_tree_unil_rl:10m rate=60r/m;
+\tlimit_conn_zone $atom_public_client_key zone=atom_tree_conn:10m;
+\tlimit_conn_zone $atom_unil_client_key zone=atom_tree_unil_conn:10m;
+"""
+
+if "zone=atom_browse_unil_rl" not in text:
+    if old_zones not in text:
+        raise SystemExit("Expected host nginx rate-limit zone block not found")
+    text = text.replace(old_zones, new_zones, 1)
+
+nginx_conf.write_text(text)
+
+text = atom_vhost.read_text()
+
+text = text.replace(
+    "  limit_req zone=atom_browse_rl burst=30 nodelay;\n"
+    "  limit_req zone=atom_browse_global_rl burst=20 nodelay;\n"
+    "  limit_req_status 429;\n",
+    "  limit_req zone=atom_browse_rl burst=30 nodelay;\n"
+    "  limit_req zone=atom_browse_unil_rl burst=60 nodelay;\n"
+    "  limit_req zone=atom_browse_global_rl burst=20 nodelay;\n"
+    "  limit_req zone=atom_browse_unil_global_rl burst=80 nodelay;\n"
+    "  limit_req_status 429;\n",
+)
+
+text = text.replace(
+    "    limit_req zone=atom_tree_rl burst=4 nodelay;\n"
+    "    limit_req_status 429;\n"
+    "    limit_conn atom_tree_conn 1;\n",
+    "    limit_req zone=atom_tree_rl burst=4 nodelay;\n"
+    "    limit_req zone=atom_tree_unil_rl burst=20 nodelay;\n"
+    "    limit_req_status 429;\n"
+    "    limit_conn atom_tree_conn 1;\n"
+    "    limit_conn atom_tree_unil_conn 2;\n",
+)
+
+atom_vhost.write_text(text)
+PY
+
+if ! nginx -t; then
+  echo "nginx -t failed; restoring backups" >&2
+  restore
+  nginx -t || true
+  exit 1
+fi
+
+systemctl reload nginx
+
+echo "Host nginx UNIL-aware rate-limit cleanup applied."
+echo "Backups:"
+echo "  $nginx_backup"
+echo "  $vhost_backup"


### PR DESCRIPTION
## Summary

This PR adds persistent OAI-PMH deleted-record support for AtoM Archives UNIL and records the related production traffic-management work.

The application now advertises `deletedRecord=persistent` in OAI-PMH `Identify`. When a published description is deleted or unpublished, AtoM stores an OAI tombstone in `oai_deleted_record`; harvesters can still query the identifier, receive a `status="deleted"` header, and no longer receive metadata for that record. If an unpublished description is republished, the tombstone is deactivated and the normal OAI record is restored.

This PR also includes the production nginx/support tooling that was part of the current operational state: route-aware crawler controls, UNIL/public rate-limit separation, print-browse mitigation scripts, schema/log analysis helpers, and updated agent deployment notes.

## Production context

This branch has already been deployed to production on 2026-07-07 after Nam validated the expected archival behavior. Production is currently pinned to the validated Docker image digest from this branch.

Deployment evidence and runbook notes were recorded in local project docs under `descr/`, including:

- `descr/staging-validation-2026-07-07-oai-pmh-persistent-deleted-records.md`
- `descr/prod-deployment-2026-07-07-oai-pmh-persistent-deleted-records.md`
- `descr/oai-pmh-ead-xml-cache-runbook.md`
- `descr/prod-vm-notes.md`

Note: the `descr/` docs are local operational docs and are not tracked in this repository.

## Validation

Validated on staging before production:

- `Identify` returns `deletedRecord=persistent`.
- Depublishing a published record creates an OAI tombstone.
- Republishing restores a normal OAI record.
- Permanently deleting a published record keeps a tombstone.
- Deleted records expose no metadata block.
- OAI Identify, OAI records, EAD/XML exports, and normal browse endpoints remained functional.

Validated on production after deployment:

- production health check passed with `fails=0 warnings=0`;
- home, dynamic FR page, browse, OAI Identify, and EAD XML returned `200`;
- OAI Identify returned `deletedRecord=persistent`;
- `oai_deleted_record` table exists;
- recent atom/nginx logs showed no fatal errors, SQLSTATE errors, 500s, or PHP-FPM `pm.max_children` warnings.

Local checks before opening this PR:

- `git diff --check`: clean
- `bash -n` on shell scripts: OK
- `python3 -m py_compile scripts/atom_nginx_traffic_stats.py`: OK

PHP lint was not run locally because the local machine does not have a `php` binary installed.